### PR TITLE
Encoding fix

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -418,6 +418,13 @@ DATE is given as european date (DD MM YYYY)."
 ;; The following is taken from icalendar.el, written by Ulf Jasper.
 
 (defun org-caldav-convert-event ()
+  "Run org-caldav-convert-event-internal with the decoded entry"
+  (let ((decoded (decode-coding-region (point-min) (point-max) 'utf-8 t)))
+    (with-temp-buffer
+      (insert decoded)
+      (org-caldav-convert-event-internal))))
+
+(defun org-caldav-convert-event-internal ()
   "Convert icalendar event in current buffer.
 Returns a list '(start-d start-t end-d end-t summary description)'
 which can be fed into `org-caldav-insert-org-entry'."


### PR DESCRIPTION
The url library gets the content length wrong if the contents are not encoded explicitly as utf-8 (this only happens when the entries contain non-ascii characters, of course). This small change fixes it for me :)
