### PR TITLE
org-caldav-goto-uid: Only look at the link text-property

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -987,8 +987,8 @@ If COMPLEMENT is non-nil, return all item without errors."
 (defun org-caldav-goto-uid ()
   "Jump to UID unter point."
   (interactive)
-  (when (equal (text-properties-at (point))
-	       '(face link))
+  (when (equal (plist-get (text-properties-at (point)) 'face)
+	       'link)
     (beginning-of-line)
     (looking-at "UID: \\(.+\\)$")
     (org-id-goto (match-string 1))))


### PR DESCRIPTION
I had a problem with link not working: for some reason, on my emacs the link had another text property, so the link (on UID) was failing. This fix it.
