### PR TITLE
kill temp org-caldav-ics-buffer when done

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -476,6 +476,7 @@ Are you really sure? ")))
     (:files 'org-caldav-files)
     (:select-tags 'org-caldav-select-tags)
     (:inbox 'org-caldav-inbox)
+    (:skip-function 'org-agenda-skip-function)
     (t (error "Key '%s' is not allowed in org-caldav-calendars" key))))
 
 (defun org-caldav-sync-calendar (&optional calendar resume)


### PR DESCRIPTION
Whenever I C-x C-s my emacs client (ie. when using start-server), I have to agree to not saving a dozen temp buffers, a bit annoying.
