### PR TITLE
Accept more than 10 TS/DL uid

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -793,7 +793,7 @@ is no UID to rewrite. Returns the UID."
      ((re-search-forward "^UID:\\(orgsexp-[0-9]+\\)" nil t)
       ;; This is a sexp entry, so do nothing.
       (match-string 1))
-     ((re-search-forward "^UID:\\(\\s-*\\)\\([A-Z][A-Z][0-9]?-\\)?\\(.+\\)\\s-*$"
+     ((re-search-forward "^UID:\\(\\s-*\\)\\([A-Z][A-Z][0-9]*-\\)?\\(.+\\)\\s-*$"
 			 nil t)
       (when (match-string 1)
 	(replace-match "" nil nil nil 1))


### PR DESCRIPTION
When the org exporter add an TS or DL prefix to an uid, it can an a
if there is more than one. This number can be greater than 9; making
org-caldav to fail to sync. Let strip as many digit as there is.
