### PR TITLE
skip-function in org-caldav-calendars sets org-agenda-skip-function

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -476,6 +476,7 @@ Are you really sure? ")))
     (:files 'org-caldav-files)
     (:select-tags 'org-caldav-select-tags)
     (:inbox 'org-caldav-inbox)
+    (:skip-function 'org-agenda-skip-function)
     (t (error "Key '%s' is not allowed in org-caldav-calendars" key))))
 
 (defun org-caldav-sync-calendar (&optional calendar resume)


### PR DESCRIPTION
Usage:

```
(setq org-caldav-calendars
 ((:calendar-id "org-home"
   :skip-function org-agenda-skip-work
   :inbox "~/org/caldav-inbox-home.org")
  (:calendar-id "org-work"
   :skip-function (org-agenda-skip-work 'inverse)
   :inbox "~/org/caldav-inbox-work.org")))
```

Could probably be an org-caldav variable that is then set first thing in
`org-caldav-generate-ics' using an outer

```
(let ((org-agenda-skip-function org-caldav-skip-function))
    rest-of-function)
```

if that feels nicer …
