### PR TITLE
Fix org-caldav-empty-calendar handling with multiple calendars

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -647,7 +647,7 @@ This removes timestamps which weren't properly removed by
 org-icalendar."
   (save-excursion
     (goto-char (point-min))
-    (when (re-search-forward "^DESCRIPTION:.*?\\(\\s-*<[^>]+>\\(–<[^>]+>\\)?\\\\n\\)" nil t)
+    (when (re-search-forward "^DESCRIPTION:.*?\\(\s*-*<[^>]+>\\(–<[^>]+>\\)?\\(\\\\n\\\\n\\)?\\)" nil t)
       (replace-match "" nil nil nil 1))))
 
 (defun org-caldav-maybe-fix-timezone ()


### PR DESCRIPTION
Upon switching to another calendar org-caldav-empty-calendar should be set to nil.
