### PR TITLE
Declare a nominal package dependency on org

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -4,6 +4,7 @@
 
 ;; Author: David Engster <dengste@eml.cc>
 ;; Keywords: calendar, caldav
+;; Package-Requires: ((org "7"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
This header ensures that when `org-caldav` is installed via `package.el` (as will [soon be possible](https://github.com/milkypostman/melpa/pull/1683)), the `org` package will also be required.
