### PR TITLE
change condition for signature change work-around

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -879,8 +879,8 @@ Returns buffer containing the ICS file."
     ;; Export events to one single ICS file.
     (if (featurep 'ox-icalendar)
 	;; New exporter (Org 8)
-	;; Signature changed in version 8.2.8
-	(if (version< org-version "8.2.8")
+	;; Signature changed in version 8.3
+	(if (version< org-version "8.3beta")
 	    (apply 'org-icalendar--combine-files nil orgfiles)
 	  (apply 'org-icalendar--combine-files orgfiles))
       (apply 'org-export-icalendar t orgfiles))


### PR DESCRIPTION
As the current master branch of org-mode has `org-version` "8.3beta" and `(version< "8.3" "8.3beta")` is `nil`, this is a better check. See discussion on commit f5c0e2728abd89.