### PR TITLE
Make sure matching is case-sensitive in org-caldav-get-uid.

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -889,7 +889,8 @@ Returns buffer containing the ICS file."
 (defun org-caldav-get-uid ()
   "Get UID for event in current buffer."
   (if (re-search-forward "^UID:\\s-*\\(.+\\)\\s-*$" nil t)
-      (let ((uid (match-string 1)))
+      (let ((case-fold-search nil)
+            (uid (match-string 1)))
 	(while (progn (forward-line)
 		      (looking-at " \\(.+\\)\\s-*$"))
 	  (setq uid (concat uid (match-string 1))))


### PR DESCRIPTION
If case-fold-search is t, the matching done to chop off possible
prefixes added by org-mode (i.e. the [A-Z][A-Z][0-9]*-) regexp, may
match a legitimate UID that just happens to have the first chunk
be two characters and followed by only numbers. This results in the
first chunk of the UID being chopped off, breaking UID matching.

This makes sure case-fold-search is set to nil in org-caldav-get-uid.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>