### PR TITLE
org-caldav-insert-org-entry now allows null UID

### DIFF
--- a/org-caldav-testsuite.el
+++ b/org-caldav-testsuite.el
@@ -381,3 +381,21 @@ Baz Bar Foo")
       (org-caldav-change-heading "third changed heading"))
     (should (looking-at "^\\*  <2009-08-08 Sat 14:00> third changed heading\n"))
     ))
+
+(ert-deftest org-caldav-insert-org-entry ()
+  "Make sure that `org-caldav-insert-org-entry' works fine."
+  (let ((entry '("01 01 2015" "19:00" "01 01 2015" "20:00" "The summary" "The description"))
+        (org-caldav-select-tags ""))
+    (cl-flet ((write-entry (uid level)
+                           (with-temp-buffer
+                             (org-mode) ; useful to set org-mode's
+                                        ; internal variables
+                             (apply #'org-caldav-insert-org-entry
+                                    (append entry (list uid level)))
+                             (buffer-string))))
+      (should (string= "* The summary\n<2015-01-01 Thu 19:00-20:00>\nThe description\n"
+                       (write-entry nil nil)))
+      (should (string= "** The summary\n<2015-01-01 Thu 19:00-20:00>\nThe description\n"
+                       (write-entry nil 2)))
+      (should (string= "* The summary\n  :PROPERTIES:\n  :ID:       1\n  :END:\n<2015-01-01 Thu 19:00-20:00>\nThe description\n"
+                       (write-entry "1" nil))))))

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -969,19 +969,25 @@ Do nothing if LEVEL is larger than `org-caldav-debug-level'."
 		      (point-min))))
 
 (defun org-caldav-insert-org-entry (start-d start-t end-d end-t
-					    summary description uid level)
+                                            summary description
+                                            &optional uid level)
   "Insert org block from given data at current position.
 START/END-D: Start/End date.  START/END-T: Start/End time.
 SUMMARY, DESCRIPTION, UID: obvious.
 Dates must be given in a format `org-read-date' can parse.
+
+If UID is nil, no UID: property is written.
+If LEVEL is nil, it defaults to 1.
+
 Returns MD5 from entry."
-  (insert (make-string level ?*) " " summary "\n")
+  (insert (make-string (or level 1) ?*) " " summary "\n")
   (insert
    (org-caldav-create-time-range start-d start-t end-d end-t) "\n")
   (when (> (length description) 0)
     (insert description "\n"))
   (forward-line -1)
-  (org-set-property "ID" (url-unhex-string uid))
+  (when uid
+    (org-set-property "ID" (url-unhex-string uid)))
   (org-set-tags-to org-caldav-select-tags)
   (md5 (buffer-substring-no-properties
 	(org-entry-beginning-position)


### PR DESCRIPTION
This commit allows nil to be passed as the UID parameter to
`org-caldav-insert-org-entry`. This is useful when automatically filling
`org-caldav-inbox` with entries generated from .ics files (e.g., from
emails).

This commit also introduces a unit test for this method.