### PR TITLE
Fix org function change

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -677,7 +677,7 @@ returned as a cons (POINT . LEVEL)."
 	 (save-excursion
 	   (let ((org-link-search-inhibit-query t)
 		 level)
-	     (org-link-search (concat "*" (nth 2 inbox)) nil nil t)
+	     (org-link-search (concat "*" (nth 2 inbox)) nil t)
 	     (setq level (1+ (org-current-level)))
 	     (org-end-of-subtree t t)
 	     (cons (point) level))))


### PR DESCRIPTION
`org-link-search' no longer takes 4 args but only 3. See b4d85b4.
