### PR TITLE
Fix regexp in org-caldav-get-uid.

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -896,7 +896,7 @@ Returns buffer containing the ICS file."
 	  (setq uid (concat uid (match-string 1))))
 	(while (string-match "\\s-+" uid)
 	  (setq uid (replace-match "" nil nil uid)))
-	(when (string-match "^\\([A-Z][A-Z][0-9]*-\\)" uid)
+	(when (string-match "^\\(\\(DL\\|SC\\|TS\\)[0-9]*-\\)" uid)
 	  (setq uid (replace-match "" nil nil uid)))
 	uid)
     (error "No UID could be found for current event.")))


### PR DESCRIPTION
Without this, UIDs have the first part stripped if they happen to start with two letters [A-F], followed by numbers, resulting in an error.

Probably fixes #58.