### PR TITLE
Ask if the user wants to create the missing inbox files

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -721,8 +721,10 @@ If RESUME is non-nil, try to resume."
     (cl-progv (mapcar 'org-caldav-var-for-key calkeys) calvalues
       (dolist (filename (append org-caldav-files
 				(list (org-caldav-inbox-file org-caldav-inbox))))
-	(when (not (file-exists-p filename))
-	  (user-error "File %s does not exist" filename)))
+        (when (not (file-exists-p filename))
+          (if (yes-or-no-p (format "File %s does not exist, create it?" filename))
+              (write-region "" nil filename)
+            (user-error "File %s does not exist" filename))))
       ;; Check if we need to do OAuth2
       (when (org-caldav-use-oauth2)
 	;; We need to do oauth2. Check if it is available.


### PR DESCRIPTION
When synchronizing several calendars, I find it annoying that `org-caldav-sync` stopped for every missing files.

This patch prompt for the user's permission to create the missing files.