### PR TITLE
org-caldav-change-timestamp: also match against time ranges

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1104,7 +1104,8 @@ is on s-expression."
   (goto-char (point-min))
   (if (search-forward "<%%(" nil t)
       'orgsexp
-    (when (re-search-forward org-maybe-keyword-time-regexp nil t)
+    (when (or (re-search-forward org-tr-regexp nil t)
+              (re-search-forward org-maybe-keyword-time-regexp nil t))
       (replace-match newtime nil t))
     (widen)))
 


### PR DESCRIPTION
This is an initial attempt at a fix for #137.

Matching against org-tr-regexp first allows correctly replacing the whole time range in cases where the start date of a range has been updated on the server.