### PR TITLE
Skip VTODO entries on CalDAV server

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -979,6 +979,10 @@ returned as a cons (POINT . LEVEL)."
 	  ;; Get sequence number
 	  (goto-char (point-min))
 	  (save-excursion
+	    (when (re-search-forward "^BEGIN:VTODO$" nil t)
+	      (message "Skipping TODO entry.")
+	      (throw 'next nil)))
+	  (save-excursion
 	    (when (re-search-forward "^SEQUENCE:\\s-*\\([0-9]+\\)" nil t)
 	      (org-caldav-event-set-sequence
 	       cur (string-to-number (match-string 1)))))


### PR DESCRIPTION
On CalDAV servers that mix Calendar and TODO entries, org-caldav syncs an empty
"No Title" entry with no UID for every TODO encountered on the server.  These
entries are not cached in the org-caldav sync db, so they are duplicated every
time you resync.  This can quickly lead to thousands of dummy entries in your
org inbox.

This patch just skips VTODO entries entirely when they are encountered.