### PR TITLE
Implement CLASS attribute of ics files

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1108,6 +1108,14 @@ property."
       (org-set-property "LOCATION" newlocation)
     (org-delete-property "LOCATION")))
 
+(defun org-caldav-change-class (newclass)
+  "Change the CLASS property from ORG item under point to
+NEWCLASS. If newclass is \"\", removes the class
+property."
+  (if (> (length newclass) 0)
+      (org-set-property "CLASS" newclass)
+    (org-delete-property "CLASS")))
+
 (defun org-caldav-change-timestamp (newtime)
   "Change timestamp from Org item under point to NEWTIME.
 Return symbol 'orgsexp if this entry cannot be changed because it
@@ -1265,14 +1273,15 @@ Do nothing if LEVEL is larger than `org-caldav-debug-level'."
 		      (point-min))))
 
 (defun org-caldav-insert-org-entry (start-d start-t end-d end-t
-                                            summary description location
+                                            summary description location class
                                             &optional uid level)
   "Insert org block from given data at current position.
 START/END-D: Start/End date.  START/END-T: Start/End time.
-SUMMARY, DESCRIPTION, LOCATION, UID: obvious.
+SUMMARY, DESCRIPTION, LOCATION, CLASS, UID: obvious.
 Dates must be given in a format `org-read-date' can parse.
 
 If LOCATION is \"\", no LOCATION: property is written.
+If CLASS is \"\", no CLASS: property is written.
 If UID is nil, no UID: property is written.
 If LEVEL is nil, it defaults to 1.
 
@@ -1288,6 +1297,9 @@ Returns MD5 from entry."
   (if (> (length location) 0)
       (org-set-property "LOCATION" location)
     (org-delete-property "LOCATION"))
+  (if (> (length class) 0)
+      (org-set-property "CLASS" class)
+    (org-delete-property "CLASS"))
   (org-set-tags-to org-caldav-select-tags)
   (md5 (buffer-substring-no-properties
 	(org-entry-beginning-position)
@@ -1472,7 +1484,7 @@ If COMPLEMENT is non-nil, return all item without errors."
 ;; The LOCATION property is added the extracted list
 (defun org-caldav-convert-event ()
   "Convert icalendar event in current buffer.
-Returns a list '(start-d start-t end-d end-t summary description location)'
+Returns a list '(start-d start-t end-d end-t summary description location class)'
 which can be fed into `org-caldav-insert-org-entry'."
   (let ((decoded (decode-coding-region (point-min) (point-max) 'utf-8 t)))
     (erase-buffer)
@@ -1515,6 +1527,9 @@ which can be fed into `org-caldav-insert-org-entry'."
 	 (location (icalendar--convert-string-for-import
                     (or (icalendar--get-event-property e 'LOCATION)
                         "")))
+	 (class (icalendar--convert-string-for-import
+                    (or (icalendar--get-event-property e 'CLASS)
+                        "")))
 	 (rrule (icalendar--get-event-property e 'RRULE))
 	 (rdate (icalendar--get-event-property e 'RDATE))
 	 (duration (icalendar--get-event-property e 'DURATION)))
@@ -1556,7 +1571,7 @@ which can be fed into `org-caldav-insert-org-entry'."
     ;; Return result
     (list start-d start-t
 	  (if end-t end-d end-1-d)
-	  end-t summary description location)))
+	  end-t summary description location class)))
 
 ;; This is adapted from url-dav.el, written by Bill Perry.
 ;; This does more error checking on the headers and retries


### PR DESCRIPTION
This patch implements the CLASS attribute for CalDAV servers. It is completely copy&paste&(search&replace) from the LOCATION attribute.

This is the companion patch to patch b32415dede200746f9bc75c247379a389f76db1e from org-mode.

This allows to control the visibilty of calendar entries. This is necessary to properly synchronize semi-public calendars, for example public and private performances of a band in one calendar.

BTW. I didn't know how to introduce this feature to README.md. LOCATION is mentioned there as unhandled, but both ox-icalendar and org-caldav support it.