### PR TITLE
Bugfix for org-caldav-create-time-range: Incorrect number of args

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1039,7 +1039,7 @@ which can only be synced to calendar. Ignoring." uid))
 		;; Sync timestamp
 		(setq timesync
 		      (org-caldav-change-timestamp
-		       (apply 'org-caldav-create-time-range (butlast eventdata 3)))))
+		       (apply 'org-caldav-create-time-range (seq-take eventdata 4)))))
 	      (when (eq org-caldav-sync-changes-to-org 'all)
 		;; Sync everything, so first remove the old one.
 		(let ((level (org-current-level)))


### PR DESCRIPTION
The function `org-caldav-create-time-range` can be called from `org-caldav-update-events-in-org` with an incorrect number of arguments. The original code passes `(butlast eventdata 3)` as arguments. However, since `org-caldav-create-time-range` expects exactly four arguments, this will fail unless `eventdata` has exactly seven elements.

The fix replaces `(butlast eventdata 3)` with `(seq-take eventdata 4)`.

I managed to trigger the failure once when I added a "note" to a Google calendar event ("DESCRIPTION:" in caldav).

Edit: On second thoughts, this bug might only be necessary if you have have added CLASS (pull request #161). Adding the fix to the main branch would still remove the latent bug.