### PR TITLE
Reset org-caldav-empty-calendar before syncing

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -712,6 +712,7 @@ Are you really sure? ")))
 The format of CALENDAR is described in `org-caldav-calendars'.
 If CALENDAR is not provided, the default values will be used.
 If RESUME is non-nil, try to resume."
+  (setq org-caldav-empty-calendar nil)
   (setq org-caldav-previous-calendar calendar)
   (let (calkeys calvalues oauth-enable)
     ;; Extrace keys and values from 'calendar' for progv binding.


### PR DESCRIPTION
Proposed (partial?) fix for issue #139

Supersedes PR #140 (use knatsakis/org-caldav branch org-caldav-empty-calendar as head fork instead of master)