### PR TITLE
Do not add UIDs to entries that match org-caldav-skip-conditions

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1138,6 +1138,26 @@ is on s-expression."
 	 (when pt
 	   (delete-region (point) pt)))))))
 
+(defun org-caldav-create-uid (file &optional bell)
+  "Set ID property on headlines missing it in FILE.
+When optional argument BELL is non-nil, inform the user with
+a message if the file was modified. This func is the same as
+org-icalendar-create-uid except that it ignores entries that
+match org-caldav-skip-conditions."
+  (let (modified-flag)
+    (org-map-entries
+     (lambda ()
+       (let ((entry (org-element-at-point)))
+         (unless (org-element-property :ID entry)
+           (unless (apply 'org-agenda-skip-entry-if org-caldav-skip-conditions)
+             (org-id-get-create)
+             (setq modified-flag t)
+             (forward-line)))))
+     nil nil 'comment)
+    (when (and bell modified-flag)
+      (message "ID properties created in file \"%s\"" file)
+      (sit-for 2))))
+
 (defun org-caldav-generate-ics ()
   "Generate ICS file from `org-caldav-files'.
 Returns buffer containing the ICS file."
@@ -1152,8 +1172,8 @@ Returns buffer containing the ICS file."
 			      (list inbox-file)))))
 	(org-export-select-tags org-caldav-select-tags)
 	(org-icalendar-exclude-tags org-caldav-exclude-tags)
-	;; We absolutely need UIDs for synchronization.
-	(org-icalendar-store-UID t)
+        ;; We create UIDs ourselves and do not rely on ox-icalendar.el
+	(org-icalendar-store-UID nil)
 	;; Does not work yet
 	(org-icalendar-include-bbdb-anniversaries nil)
 	(icalendar-uid-format "orgsexp-%h")
@@ -1169,6 +1189,9 @@ Returns buffer containing the ICS file."
 	   ";TZID=%Z:%Y%m%dT%H%M%S")
 	  (t
 	   ":%Y%m%dT%H%M%S"))))
+    (dolist (orgfile orgfiles)
+      (with-current-buffer (org-get-agenda-file-buffer orgfile)
+        (org-caldav-create-uid orgfile t)))
     (set icalendar-file (make-temp-file "org-caldav-"))
     (org-caldav-debug-print 1 (format "Generating ICS file %s."
 				      (symbol-value icalendar-file)))


### PR DESCRIPTION
Please consider merging this.

With this patch, UIDs will not be added to org entries that match org-caldav-skip-conditions and will not be synced anyway.

So, by using a skip condition (e.g.: 'nottimestamp), one can avoid _polluting_ the org file with useless UIDs (UIDs will be added only to entries with a timestamp).