### PR TITLE
fix binding of backtab: `backward-button' instead of `forward-button'

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1410,7 +1410,7 @@ See also `org-caldav-save-directory'."
 (defvar org-caldav-sync-results-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map [(tab)] 'forward-button)
-    (define-key map [(backtab)] 'forward-button)
+    (define-key map [(backtab)] 'backward-button)
     map)
   "Keymap for org-caldav result buffer.")
 


### PR DESCRIPTION
Fix a minor error introduced in my pull request #172.

Great to see you maintaining this package again!