### PR TITLE
Fix: tags being inserted in the entry body, not headline

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1360,6 +1360,7 @@ Returns MD5 from entry."
   (when uid
     (org-set-property "ID" (url-unhex-string uid)))
   (org-caldav-change-location location)
+  (org-back-to-heading)
   (org-set-tags-to org-caldav-select-tags)
   (md5 (buffer-substring-no-properties
 	(org-entry-beginning-position)


### PR DESCRIPTION
`org-set-tags' assumes that the cursor is already on a headline. I have been getting results like:

    *** Example Event
    :PROPERTIES:
    :ID:       1237293742980p20138-298
    :END:
    <2019-12-22 Sun 06:30-18:30>  :export:

This commit ensures that the select tags are put on the headline.