### PR TITLE
Replace org-maybe-keyword-time-regexp (fix for Org 9.4)

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1140,7 +1140,7 @@ which can only be synced to calendar. Ignoring." uid))
       ;; Check if a timestring is in the heading
       (goto-char start)
       (save-excursion
-	(when (re-search-forward org-maybe-keyword-time-regexp end t)
+        (when (re-search-forward org-ts-regexp-both end t)
 	  ;; Check if timestring is at the beginning or end of heading
 	  (if (< (- end (match-end 0))
 		 (- (match-beginning 0) start))
@@ -1172,7 +1172,11 @@ is on s-expression."
   (if (search-forward "<%%(" nil t)
       'orgsexp
     (when (or (re-search-forward org-tr-regexp nil t)
-              (re-search-forward org-maybe-keyword-time-regexp nil t))
+              (and (re-search-forward "org-planning-line-re" nil t)
+                   (org-at-planning-p)
+                   (progn
+                     (org-skip-whitespace)
+                     (looking-at org-ts-regexp-both))))
       (replace-match newtime nil t))
     (widen)))
 


### PR DESCRIPTION
I have followed a tip published on orgmode mailing list (https://www.mail-archive.com/emacs-orgmode@gnu.org/msg127148.html). Seems to fix the problem, although I haven't tested incredibly thoroughly.