### PR TITLE
Prevent "Could not find UID" error (#230)

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -817,14 +817,14 @@ If RESUME is non-nil, try to resume."
 	    calvalues (append calvalues (list (nth (1+ i) calendar)))))
     (cl-progv (mapcar 'org-caldav-var-for-key calkeys) calvalues
       (when (org-caldav-sync-do-org->cal)
-        (let ((files-for-sync (org-caldav-get-org-files-for-sync)))
-          (dolist (filename files-for-sync)
+	(let ((files-for-sync (org-caldav-get-org-files-for-sync)))
+	  (dolist (filename files-for-sync)
 	    (when (not (file-exists-p filename))
 	      (if (yes-or-no-p (format "File %s does not exist, create it?" filename))
 		  (write-region "" nil filename)
-	        (user-error "File %s does not exist" filename))))
-          ;; prevent https://github.com/dengste/org-caldav/issues/230
-          (org-id-update-id-locations files-for-sync)))
+		(user-error "File %s does not exist" filename))))
+	  ;; prevent https://github.com/dengste/org-caldav/issues/230
+	  (org-id-update-id-locations files-for-sync)))
       ;; Check if we need to do OAuth2
       (when (org-caldav-use-oauth2)
 	;; We need to do oauth2. Check if it is available.

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1248,10 +1248,9 @@ is on s-expression."
   "Put current item in backup file."
   (let ((item (buffer-substring (org-entry-beginning-position)
 				(org-entry-end-position))))
-    (with-current-buffer (find-file-noselect org-caldav-backup-file)
-      (goto-char (point-max))
+    (with-temp-buffer
       (insert item "\n")
-      (save-buffer))))
+      (write-region (point-min) (point-max) org-caldav-backup-file t))))
 
 (defun org-caldav-skip-function (backend)
   (when (eq backend 'icalendar)

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -817,11 +817,14 @@ If RESUME is non-nil, try to resume."
 	    calvalues (append calvalues (list (nth (1+ i) calendar)))))
     (cl-progv (mapcar 'org-caldav-var-for-key calkeys) calvalues
       (when (org-caldav-sync-do-org->cal)
-	(dolist (filename (org-caldav-get-org-files-for-sync))
-	  (when (not (file-exists-p filename))
-	    (if (yes-or-no-p (format "File %s does not exist, create it?" filename))
-		(write-region "" nil filename)
-	      (user-error "File %s does not exist" filename)))))
+        (let ((files-for-sync (org-caldav-get-org-files-for-sync)))
+          (dolist (filename files-for-sync)
+	    (when (not (file-exists-p filename))
+	      (if (yes-or-no-p (format "File %s does not exist, create it?" filename))
+		  (write-region "" nil filename)
+	        (user-error "File %s does not exist" filename))))
+          ;; prevent https://github.com/dengste/org-caldav/issues/230
+          (org-id-update-id-locations files-for-sync)))
       ;; Check if we need to do OAuth2
       (when (org-caldav-use-oauth2)
 	;; We need to do oauth2. Check if it is available.


### PR DESCRIPTION
Sometimes, `org-caldav-files` is missing from `org-id-files`, which causes an error "Could not find UID" (#230).

This PR prevents the error by updating the org-id locations before searching for any IDs.

Note, upstream org-mode has also pushed a patch that should prevent the problem:

https://list.orgmode.org/87r11un9in.fsf@localhost/T/#t

But, that fix is only on the bleeding-edge of Org, not yet on the stable release. Also, I think this PR would be useful anyways, to protect against unforeseen edge cases where the needed files are missing from the org-id database.