### PR TITLE
Fix timestamp & ID bugs to make the unit tests work again

### DIFF
--- a/org-caldav-testsuite.el
+++ b/org-caldav-testsuite.el
@@ -2,7 +2,7 @@
 ;; Copyright, authorship, license: see org-caldav.el.
 
 ;; Run it from the org-caldav directory like this:
-;;   emacs -Q -L . --eval '(setq org-caldav-url "CALDAV-URL")' -l org-caldav-testsuite.el -f ert
+;;   TZ="Europe/Berlin" emacs -Q -L . --eval '(setq org-caldav-url "CALDAV-URL")' -l org-caldav-testsuite.el -f ert
 ;; On the server, there must already exist two calendars "test1" and "test2".
 ;; These will completely wiped by running this test!
 
@@ -17,6 +17,7 @@
 
 (defvar org-caldav-test-calendar-names '("test1" "test2"))
 
+(setq org-caldav-delete-calendar-entries 'always)
 (setq org-caldav-backup-file nil)
 (setq org-caldav-test-preamble
       "BEGIN:VCALENDAR
@@ -123,6 +124,10 @@ moose
 ;; All events after sync.
 (setq org-caldav-test-allevents
       '("orgcaldavtest@org1" "orgcaldavtest-org2" "orgcaldavtest@cal1" "orgcaldavtest-cal2"))
+
+(setq org-caldav-test-sync-result
+      '(("test1" "orgcaldavtest@cal1" new-in-cal cal->org)
+	("test1" "orgcaldavtest-cal2" new-in-cal cal->org)))
 
 ;; Test files.
 (defun org-caldav-test-calendar-empty-p ()
@@ -422,7 +427,7 @@ moose
 
 (ert-deftest org-caldav-03-insert-org-entry ()
   "Make sure that `org-caldav-insert-org-entry' works fine."
-  (let ((entry '("01 01 2015" "19:00" "01 01 2015" "20:00" "The summary" "The description" "location"))
+  (let ((entry '("01 01 2015" "19:00" "01 01 2015" "20:00" "The summary" "The description" "location" nil))
         (org-caldav-select-tags ""))
     (cl-flet ((write-entry (uid level)
                            (with-temp-buffer
@@ -564,10 +569,10 @@ moose
   (should (org-caldav-get-event "orgcaldavtest@cal1"))
   (should (org-caldav-get-event "orgcaldavtest-cal2"))
   ;; Sync result
-  (should (equal
-	   '(("test1" "orgcaldavtest@cal1" new-in-cal cal->org)
-	     ("test1" "orgcaldavtest-cal2" new-in-cal cal->org))
-	   org-caldav-sync-result))
+  (should (or (equal org-caldav-test-sync-result
+	             org-caldav-sync-result)
+              (equal (reverse org-caldav-test-sync-result)
+	             org-caldav-sync-result)))
   (org-caldav-test-cleanup))
 
 ;; Check that we are able to detect when an Org file was removed from

--- a/org-caldav-testsuite.el
+++ b/org-caldav-testsuite.el
@@ -3,8 +3,17 @@
 
 ;; Run it from the org-caldav directory like this:
 ;;   TZ="Europe/Berlin" emacs -Q -L . --eval '(setq org-caldav-url "CALDAV-URL")' -l org-caldav-testsuite.el -f ert
+;;
 ;; On the server, there must already exist two calendars "test1" and "test2".
 ;; These will completely wiped by running this test!
+;;
+;; Hint: In case you need a test server, one lightweight option is:
+;;    docker run -v /path/to/data:/data tomsquest/docker-radicale
+;; Then, you can create the test1 calendar from Thunderbird like so:
+;; Thunderbird -> New Calendar -> Network -> Location:
+;; http://localhost:5232/test/test1/ (the trailing slash is
+;; important), with username "test" and blank password. Then add an
+;; event from Thunderbird to make sure the calendar exists.
 
 (require 'ert)
 (require 'org)

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1201,7 +1201,8 @@ which can only be synced to calendar. Ignoring." uid))
       ;; Check if a timestring is in the heading
       (goto-char start)
       (save-excursion
-        (when (re-search-forward org-ts-regexp-both end t)
+        ;; FIXME org-maybe-keyword-time-regexp is deprecated
+	(when (re-search-forward org-maybe-keyword-time-regexp end t)
 	  ;; Check if timestring is at the beginning or end of heading
 	  (if (< (- end (match-end 0))
 		 (- (match-beginning 0) start))
@@ -1233,11 +1234,8 @@ is on s-expression."
   (if (search-forward "<%%(" nil t)
       'orgsexp
     (when (or (re-search-forward org-tr-regexp nil t)
-              (and (re-search-forward "org-planning-line-re" nil t)
-                   (org-at-planning-p)
-                   (progn
-                     (org-skip-whitespace)
-                     (looking-at org-ts-regexp-both))))
+              ;; FIXME org-maybe-keyword-time-regexp is deprecated
+              (re-search-forward org-maybe-keyword-time-regexp nil t))
       (replace-match newtime nil t))
     (widen)))
 

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -195,7 +195,11 @@ has no effect on the icalendar exporter."
 (defcustom org-caldav-backup-file
   (expand-file-name "org-caldav-backup.org" user-emacs-directory)
   "Name of the file where org-caldav should backup entries.
-Set this to nil if you don't want any backups."
+Set this to nil if you don't want any backups.
+
+Note that the ID property of the backup entry is renamed to
+OLDID, to prevent org-id-find from returning the backup entry in
+future syncs."
   :type 'file)
 
 (defcustom org-caldav-show-sync-results 'with-headings
@@ -1259,6 +1263,14 @@ is on s-expression."
 				(org-entry-end-position))))
     (with-temp-buffer
       (insert item "\n")
+      ;; Rename the ID property to OLDID, to prevent org-id-find from
+      ;; returning the backup entry in future syncs
+      (goto-char (point-min))
+      (let* ((entry (org-element-at-point))
+             (uid (org-element-property :ID entry)))
+        (when uid
+          (org-set-property "OLDID" uid)
+          (org-delete-property "ID")))
       (write-region (point-min) (point-max) org-caldav-backup-file t))))
 
 (defun org-caldav-skip-function (backend)


### PR DESCRIPTION
Most of the unit tests currently fail on recent versions of Emacs and Org. There are multiple bugs causing this, mainly related to timestamp and ID handling; some of the problems were caused by breaking changes in upstream Org mode since org-caldav was last updated.

This PR fixes the unit tests as well as underlying bugs. The commit messages contained within this PR have some more details about the specific bugs and when they were introduced.

Fixes #251, fixes #230 