### PR TITLE
fix: never emit shortening ellipsis in "(setq org-caldav-previous-files ...)"

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -2027,7 +2027,10 @@ See also `org-caldav-save-directory'."
       (insert "\n"))
     ;; Save the current value of org-caldav-files
     (insert "(setq org-caldav-previous-files '"
-	    (prin1-to-string org-caldav-files) ")\n")
+            (let ((print-length nil)
+                  (print-level nil))
+	            (prin1-to-string org-caldav-files))
+      ")\n")
     ;; Save it.
     (write-region (point-min) (point-max)
 		  (org-caldav-sync-state-filename org-caldav-calendar-id))))


### PR DESCRIPTION
with a large number of calendar-files, the unfixed code will create malformed lisp forms containing `...`  in the `.org-caldav-sync/org-caldav-hash.el` files:

```
(setq org-caldav-previous-files '("my-file.org" ...))
```

leading to this:

```
Debugger entered--Lisp error: (wrong-type-argument sequencep \...)
  mapconcat(identity (\...) ",")
  #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_26>()
  funcall(#<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_26>)
  (let ((org-caldav-calendar-id '"personal") (org-caldav-files '(foo bar baz ...))) (funcall '#<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_26>))
  eval((let ((org-caldav-calendar-id '"personal") (org-caldav-files '(foo bar baz ...)))) (funcall '#<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_26>)))
  org-caldav-sync-calendar((:calendar-id "personal" :files (foo bar baz ...)))
  org-caldav-sync()
  funcall-interactively(org-caldav-sync)
  call-interactively(org-caldav-sync nil nil)
  command-execute(org-caldav-sync)
```

This should make it never print omit-ellipses.