### PR TITLE
Fix: Don't trigger error in org-id

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -971,7 +971,8 @@ If RESUME is non-nil, try to resume."
 		  (write-region "" nil filename)
 		(user-error "File %s does not exist" filename))))
 	  ;; prevent https://github.com/dengste/org-caldav/issues/230
-	  (org-id-update-id-locations files-for-sync)))
+	  (when org-id-track-globally
+	    (org-id-update-id-locations files-for-sync t))))
       ;; Check if we need to do OAuth2
       (when (org-caldav-use-oauth2)
 	;; We need to do oauth2. Check if it is available.


### PR DESCRIPTION
org-id-update-id-locations signals an error if org-id-track-globally is nil.

Moreover, this commit makes sure we call it with the SILENT parameter set t to suppress messages.