### PR TITLE
ICloud calendar support

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -640,8 +640,7 @@ Also sets `org-caldav-empty-calendar' if calendar is empty."
   (org-caldav-check-dav (org-caldav-events-url))
   (let* ((output (org-caldav-url-dav-get-properties
 		  (org-caldav-events-url) "resourcetype"))
-	 (status (plist-get (cdar output) 'DAV:status))
-         )
+	 (status (plist-get (cdar output) 'DAV:status)))
     (when (and (stringp status) (string= status ""))
       (setq status 404))
     ;; We accept any 2xx status. Since some CalDAV servers return 404


### PR DESCRIPTION
icloud calendar CalDav has three places that are implemented differently.
1. It can return empty string "" on status:Dav for a calendar.
2. for each .ics, it returns two props, one without resource type.
3. It doesn't use Dav namespace for props