### PR TITLE
Implement recurring events and todos

### DIFF
--- a/doc/org-caldav.org
+++ b/doc/org-caldav.org
@@ -308,6 +308,44 @@ to prevent the CATEGORY from being exported to iCalendar. This problem
 only seems to affect some CalDav servers: in particular, NextCloud
 is affected, but Radicale does not seem to experience this problem.
 
+** Behavior of recurring TODO deadlines without a start time
+:PROPERTIES:
+:CUSTOM_ID: recur-deadline
+:END:
+
+Technically, the [[https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.4][iCalendar spec]] requires repeating events and todos
+(i.e. having an ~RRULE~ property) to have a starting time (~DTSTART~
+in iCalendar, equivalent to ~SCHEDULED~ in Org TODOs).  This means
+that, a TODO with a repeating ~DEADLINE~ but without a ~SCHEDULED~
+property, such as below, is not allowed by the iCalendar spec:
+
+#+begin_src org
+  ,* TODO An example todo with a repeating deadline and no start time
+  DEADLINE: <2024-09-15 Sun +1w>
+#+end_src
+
+This is a clear shortcoming of the iCalendar spec, because it /does/
+allow tasks to have a standalone deadline without a starting time, but
+/doesn't/ allow such tasks to repeat.
+
+By default, ~ox-icalendar~ follows the iCalendar spec, and when
+exporting a TODO with a repeating ~DEADLINE~ but no ~SCHEDULED~
+timestamp, will add a start time based on
+~org-deadline-warning-days~. On future syncs, this start time will be
+inserted into Org as a ~SCHEDULED~ timestamp.
+
+However, in practice, many iCalendar implementations ignore this
+limitation, and allow Todos with ~DEADLINE~ (~DUE~) times to have
+repeaters (~RRULE~), even if they are missing ~SCHEDULED~ (~DTSTART~)
+times. If your CalDav server allows this, then you may set the
+variable ~org-icalendar-todo-unscheduled-start~ to ~nil~.  This will
+prevent ~ox-icalendar~ from adding a start time to such TODOs, thus
+preventing the ~SCHEDULED~ timestamp from being inserted on future
+syncs.
+
+See [[#recur-event-todo][Repeating events and todos]] for more details about how org-caldav
+handles repeating events and todos.
+
 * Compatible CalDav servers
 :PROPERTIES:
 :CUSTOM_ID:       caldav-servers
@@ -455,6 +493,26 @@ entry in Org /and/ in the calendar, the changes in the calendar will
 be lost. I might implement proper conflict handling some day, but
 don't hold your breath (patches are welcome, of course).
 
+** Repeating events and todos
+:PROPERTIES:
+:CUSTOM_ID: recur-event-todo
+:END:
+
+Org-caldav has basic support for repeating events and todos. In
+particular, simple Org timestamp repeaters such as ~+3d~ or ~+1m~ can
+be succesfully sync'd bidirectionally.
+
+However, complex iCalender recurrences, such as "repeat on the 2nd
+Tuesday of each month until X date", are not supported.
+
+For Org TODOs with both ~SCHEDULED~ and ~DEADLINE~ timestamps, each of
+the timestamps must have the same repeater, otherwise the behavior is
+undefined.
+
+Furthermore, the behavior of Org TODOs with a repeating ~DEADLINE~
+timestamp, but no ~SCHEDULED~ timestamp, has some subtleties; see the
+configuration section: [[#recur-deadline][Behavior of recurring TODO deadlines without a start time]].
+
 ** How syncing happens (a.k.a. David's little CalDAV rant)
 
 (This is probably not interesting, so you can skip this.)
@@ -589,10 +647,6 @@ report, please make very sure you have removed personal information
 from those events.
 
 * Known Bugs
-
-- Recurring events created or changed on the calendar side cannot be
-  synced (they will work fine as long as you manage them in Org,
-  though).
 
 - Syncing is currently pretty slow since everything is done
   synchronously.

--- a/org-caldav-tests.el
+++ b/org-caldav-tests.el
@@ -503,16 +503,23 @@ Org task 2
     ))
 
 (ert-deftest org-caldav-03-insert-org-entry ()
-  "Make sure that `org-caldav-insert-org-entry' works fine."
-  (let ((entry '("01 01 2015" "19:00" "01 01 2015" "20:00" "The summary" "The description" "location" nil))
+  "Make sure that `org-caldav-insert-org-event-or-todo' works fine."
+  (let ((entry '((start-d . "01 01 2015")
+                 (start-t . "19:00")
+                 (end-d ."01 01 2015")
+                 (end-t . "20:00")
+                 (summary . "The summary")
+                 (description . "The description")
+                 (location . "location")))
         (org-caldav-select-tags ""))
     (cl-flet ((write-entry (uid level)
                            (with-temp-buffer
                              (org-mode) ; useful to set org-mode's
                                         ; internal variables
-                             (apply #'org-caldav-insert-org-entry
-                                    (append entry (list uid level)))
-                             (setq foo (buffer-string)))))
+                             (org-caldav-insert-org-event-or-todo
+                              (append entry `((uid . ,uid)
+                                              (level . ,level))))
+                             (buffer-string))))
       (should (string-match (concat
 			     "\\*\\s-+The summary\n"
 			     "\\s-*:PROPERTIES:\n"

--- a/org-caldav-tests.el
+++ b/org-caldav-tests.el
@@ -1173,17 +1173,32 @@ the result matches the regular expression OUTPUT."
 :END:
 <2024-05-25 Sat \\+7d>"))
 
-(ert-deftest org-caldav-13b-test-simple-repeating-todo ()
+(ert-deftest org-caldav-13b-test-simple-repeating-todo-dtstart ()
   (let ((org-caldav-sync-todo t)
         (org-icalendar-include-todo 'all))
     (org-caldav-test-input-output-entry
-     "* TODO Simple repeating todo
+     "* TODO Simple repeating scheduled todo
 SCHEDULED: <2024-06-08 Sat +3d>
 :PROPERTIES:
-:ID:       test-simple-repeating-todo
+:ID:       test-simple-repeating-todo-dtstart
 :END:"
-     "* TODO Simple repeating todo
+     "* TODO Simple repeating scheduled todo
 SCHEDULED: <2024-06-08 Sat \\+3d>
 :PROPERTIES:
-:ID:\\s-+test-simple-repeating-todo
+:ID:\\s-+test-simple-repeating-todo-dtstart
+:END:")))
+
+(ert-deftest org-caldav-13c-test-simple-repeating-todo-dtstart-due ()
+  (let ((org-caldav-sync-todo t)
+        (org-icalendar-include-todo 'all))
+    (org-caldav-test-input-output-entry
+     "* TODO Simple repeating scheduled todo with deadline
+SCHEDULED: <2024-06-08 Sat +3d> DEADLINE: <2024-06-10 Mon +3d>
+:PROPERTIES:
+:ID:       test-simple-repeating-todo-dtstart-due
+:END:"
+     "* TODO Simple repeating scheduled todo with deadline
+\\(SCHEDULED: <2024-06-08 Sat \\+3d> DEADLINE: <2024-06-10 Mon \\+3d>\\|DEADLINE: <2024-06-10 Mon \\+3d> SCHEDULED: <2024-06-08 Sat \\+3d>\\)
+:PROPERTIES:
+:ID:\\s-+test-simple-repeating-todo-dtstart-due
 :END:")))

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -2222,9 +2222,7 @@ which can be fed into `org-caldav-insert-org-event-or-todo'."
 		             "No Title")))
             (description . ,(icalendar--convert-string-for-import
 		             (or (icalendar--get-event-property e 'DESCRIPTION)
-			         "")))
-            (rrule . ,(icalendar--get-event-property e 'RRULE))
-            (rdate . ,(icalendar--get-event-property e 'RDATE)))))
+			         ""))))))
     (if is-todo
         (org-caldav-convert-event-or-todo--todo e zone-map eventdata-alist)
       (org-caldav-convert-event-or-todo--event e zone-map eventdata-alist))))
@@ -2241,7 +2239,8 @@ which can be fed into `org-caldav-insert-org-event-or-todo'."
 		       (plist-get dtend-plist 'event-property) -1
 		       (plist-get dtend-plist 'zone)))
 	 e-type
-	 (duration (icalendar--get-event-property e 'DURATION)))
+	 (duration (icalendar--get-event-property e 'DURATION))
+         (rrule . ,(icalendar--get-event-property e 'RRULE)))
     (when (string-match "^\\(?:\\(DL\\|S\\):\s+\\)?\\(.*\\)$" summary)
       (setq e-type (match-string 1 summary))
       (setq summary (match-string 2 summary)))
@@ -2258,6 +2257,12 @@ which can be fed into `org-caldav-insert-org-event-or-todo'."
 		     summary))
 	(setq dtend-dec dtend-dec-d)
 	(setq dtend-1-dec dtend-1-dec-d)))
+    (when rrule
+      (setq eventdata-alist
+            (append
+             eventdata-alist
+             `((recurring-diary-sexp . ,(icalendar--convert-recurring-to-diary
+                                         e dtstart-dec start-t end-t))))))
     (let ((end-t (org-caldav--datetime-to-colontime
 		  dtend-dec e 'DTEND start-t)))
       ;; Return result

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -2222,7 +2222,9 @@ which can be fed into `org-caldav-insert-org-event-or-todo'."
 		             "No Title")))
             (description . ,(icalendar--convert-string-for-import
 		             (or (icalendar--get-event-property e 'DESCRIPTION)
-			         ""))))))
+			         "")))
+            (rrule . ,(icalendar--get-event-property e 'RRULE))
+            (rdate . ,(icalendar--get-event-property e 'RDATE)))))
     (if is-todo
         (org-caldav-convert-event-or-todo--todo e zone-map eventdata-alist)
       (org-caldav-convert-event-or-todo--event e zone-map eventdata-alist))))

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1845,13 +1845,15 @@ Returns MD5 from entry."
           ;; TODO Handle UNTIL rrule property; ox-icalendar currently
           ;; uses DEADLINE for that in certain cases
           (when .start-d
+            ;; FIXME use `org-schedule' or `org-deadline' instead
+            ;; (here and elsewhere)
             (org--deadline-or-schedule
-             nil 'scheduled (org-caldav-convert-to-org-time
+             nil 'scheduled (org-caldav--convert-to-org-time-with-brackets
                              .start-d .start-t
                              .rrule-props)))
           (when .due-d
             (org--deadline-or-schedule
-             nil 'deadline (org-caldav-convert-to-org-time
+             nil 'deadline (org-caldav--convert-to-org-time-with-brackets
                             .due-d .due-t
                             .rrule-props)))
           (when .completed-d
@@ -1958,7 +1960,11 @@ Sets the block's tags, and return its MD5."
   "Insert org time stamp using DATE and TIME at point.
 DATE is given as european date (DD MM YYYY)."
   (insert
-   "<" (org-caldav-convert-to-org-time date time) ">"))
+   (org-caldav--convert-to-org-time-with-brackets date time)))
+
+(defun org-caldav--convert-to-org-time-with-brackets (&rest args)
+  "Wraps `org-caldav-convert-to-org-time' results with angle brackets."
+  (concat "<" (apply 'org-caldav-convert-to-org-time args) ">"))
 
 (defun org-caldav-convert-to-org-time (date &optional time rrule-props)
   "Convert to org time stamp using DATE and TIME.

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1854,7 +1854,10 @@ Returns MD5 from entry."
           (org-caldav-insert-org-entry--wrapup))
       (insert (make-string (or .level 1) ?*) " " .summary "\n")
       (insert (if org-adapt-indentation "  " "")
-              (org-caldav-create-time-range .start-d .start-t .end-d .end-t .e-type) "\n")
+              (if .recurring-diary-sexp
+                  (format "<%s>" (string-trim-right .recurring-diary-sexp))
+                (org-caldav-create-time-range .start-d .start-t .end-d .end-t .e-type))
+               "\n")
       (org-caldav--insert-description .description)
       (forward-line -1)
       (when .uid
@@ -2221,6 +2224,11 @@ which can be fed into `org-caldav-insert-org-event-or-todo'."
         (setq eventdata-alist
               (append
                eventdata-alist
+               ;; TODO: Reimplement
+               ;; icalendar--convert-recurring-to-diary to prefer
+               ;; org-date, org-cyclic, etc over diary-date,
+               ;; diary-cyclic so that order of variables follows ISO
+               ;; instead of evilly depending on calendar-date-style
                `((recurring-diary-sexp . ,(icalendar--convert-recurring-to-diary
                                            e dtstart-dec start-t end-t))))))
       ;; Return result

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -2240,7 +2240,7 @@ which can be fed into `org-caldav-insert-org-event-or-todo'."
 		       (plist-get dtend-plist 'zone)))
 	 e-type
 	 (duration (icalendar--get-event-property e 'DURATION))
-         (rrule . ,(icalendar--get-event-property e 'RRULE)))
+         (rrule (icalendar--get-event-property e 'RRULE)))
     (when (string-match "^\\(?:\\(DL\\|S\\):\s+\\)?\\(.*\\)$" summary)
       (setq e-type (match-string 1 summary))
       (setq summary (match-string 2 summary)))
@@ -2257,14 +2257,14 @@ which can be fed into `org-caldav-insert-org-event-or-todo'."
 		     summary))
 	(setq dtend-dec dtend-dec-d)
 	(setq dtend-1-dec dtend-1-dec-d)))
-    (when rrule
-      (setq eventdata-alist
-            (append
-             eventdata-alist
-             `((recurring-diary-sexp . ,(icalendar--convert-recurring-to-diary
-                                         e dtstart-dec start-t end-t))))))
     (let ((end-t (org-caldav--datetime-to-colontime
 		  dtend-dec e 'DTEND start-t)))
+      (when rrule
+        (setq eventdata-alist
+              (append
+               eventdata-alist
+               `((recurring-diary-sexp . ,(icalendar--convert-recurring-to-diary
+                                           e dtstart-dec start-t end-t))))))
       ;; Return result
       (append `((component-type . event)
 		(end-d

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1495,25 +1495,16 @@ which can only be synced to calendar. Ignoring." uid))
                                 (when (re-search-forward org-tsr-regexp nil t)
                                   (replace-match tr nil t)))))
                       (widen))
-                  ;; Sync deadline
-                  (when .due-d
-                    (org--deadline-or-schedule
-                     nil 'deadline (org-caldav--convert-to-org-time-with-brackets
-                                    .due-d .due-t
-                                    .rrule-props)))
                   ;; Sync scheduled
                   (when .start-d
                     (org--deadline-or-schedule
-                     nil 'scheduled (org-caldav--convert-to-org-time-with-brackets
-                                     .start-d .start-t
-                                     .rrule-props))
-                    (let ((until (assoc 'UNTIL .rrule-props)))
-                      (when until
-                        (org--deadline-or-schedule
-                         nil 'deadline
-                         (org-caldav--convert-to-org-time-with-brackets
-                          (icalendar--datetime-to-european-date until)
-                          (when .start-t (icalendar--datetime-to-colontime until)))))))
+                     nil 'scheduled (org-caldav-convert-to-org-time
+                                     .start-d .start-t)))
+                  ;; Sync deadline
+                  (when .due-d
+                    (org--deadline-or-schedule
+                     nil 'deadline (org-caldav-convert-to-org-time
+                                    .due-d .due-t)))
                   ;; Sync completion time
                   (when .completed-d (org-add-planning-info
                                       'closed (org-caldav-convert-to-org-time
@@ -1851,23 +1842,20 @@ Returns MD5 from entry."
                     " " prio .summary "\n"))
           (org-caldav--insert-description .description)
           (forward-line -1)
+          ;; TODO Handle UNTIL rrule property; ox-icalendar currently
+          ;; uses DEADLINE for that in certain cases
+          (when .start-d
+            ;; FIXME use `org-schedule' or `org-deadline' instead
+            ;; (here and elsewhere)
+            (org--deadline-or-schedule
+             nil 'scheduled (org-caldav--convert-to-org-time-with-brackets
+                             .start-d .start-t
+                             .rrule-props)))
           (when .due-d
             (org--deadline-or-schedule
              nil 'deadline (org-caldav--convert-to-org-time-with-brackets
                             .due-d .due-t
                             .rrule-props)))
-          (when .start-d
-            (org--deadline-or-schedule
-             nil 'scheduled (org-caldav--convert-to-org-time-with-brackets
-                             .start-d .start-t
-                             .rrule-props))
-            (let ((until (assoc 'UNTIL .rrule-props)))
-              (when until
-                (org--deadline-or-schedule
-                 nil 'deadline
-                 (org-caldav--convert-to-org-time-with-brackets
-                  (icalendar--datetime-to-european-date until)
-                  (when .start-t (icalendar--datetime-to-colontime until)))))))
           (when .completed-d
             (org-add-planning-info 'closed (org-caldav-convert-to-org-time .completed-d .completed-t)))
           (org-caldav-set-org-tags .categories)

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1092,6 +1092,7 @@ ICSBUF is the buffer containing the exported iCalendar file."
           (org-caldav-fix-todo-status-percent-state)
           (org-caldav-fix-categories)
           (org-caldav-fix-todo-dtstart)
+          (org-caldav-fix-todo-remove-until)
           (message "Putting event %d of %d Org --> Cal" counter (length events))
           (if (org-caldav-put-event icsbuf)
               (org-caldav-event-set-etag cur 'put)
@@ -1306,6 +1307,35 @@ also look if there is a deadline."
                 (or (org-get-scheduled-time nil) (org-get-deadline-time nil))
               (org-get-scheduled-time nil)))
           (delete-region (line-beginning-position) (+ 1 (line-end-position))))))))
+
+(defun org-caldav-fix-todo-remove-until ()
+  "Remove RRULE UNTIL from VTODOs in ox-icalendar export.
+ox-icalendar has confusing behavior around RRULE UNTIL in todos:
+Todos with repeating SCHEDULED timestamp and non-repeating
+DEADLINE timestamp treat the latter as RRULE UNTIL.  This makes
+sense for users who set
+`org-agenda-skip-scheduled-repeats-after-deadline' but that
+option is not well known and nil by default.  A better and more
+flexible approach (that applies to both Todos and non-Todos)
+would be to use diary-style sexp timestamps for UNTIL and other
+complex RRULEs, but this requires implementing sexp timestamps
+during import, as well as upstream work to fix sexp timestamps on
+export (ox-icalendar export of sexp timestamps appears broken as
+of current writing 2024-08-26).  For now, we simply ignore UNTIL
+during Cal->Org, and strip out UNTIL during Org->Cal, until we
+figure out a better path forward -- ideally in collaboration with
+upstream ox-icalendar."
+  (save-excursion
+    (goto-char (point-min))
+    (when (search-forward "BEGIN:VTODO" nil t)
+      (when (re-search-forward "^RRULE:\\(.*UNTIL=[^\^M\n]+\\)" nil t)
+        (replace-match
+         (save-match-data
+           (string-join (cl-loop for x in (string-split (match-string 1) ";")
+                                 unless (string-prefix-p "UNTIL=" x)
+                                 collect x)
+                        ";"))
+         nil nil nil 1)))))
 
 (defun org-caldav-inbox-file (inbox)
   "Return file name associated with INBOX.

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1899,8 +1899,6 @@ Returns MD5 from entry."
                     " " prio .summary "\n"))
           (org-caldav--insert-description .description)
           (forward-line -1)
-          ;; TODO Handle UNTIL rrule property; ox-icalendar currently
-          ;; uses DEADLINE for that in certain cases
           (when .start-d
             ;; FIXME use `org-schedule' or `org-deadline' instead
             ;; (here and elsewhere)


### PR DESCRIPTION
Fixes #150 

This seems to be working, but I plan to add some unit tests before merging.

Also should update the documentation to note this is supported now, but only for simple cases (no iCal UNTIL or COUNT properties), and also to note some subtleties in the case of TODOs (e.g. the user may want to set `org-icalendar-todo-unscheduled-start`).

I'm opening the PR now for visibility and so people can test it out if they like.