### PR TITLE
Add an option to skip UID generation

### DIFF
--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1771,6 +1771,8 @@ Returns buffer containing the ICS file."
       (with-current-buffer (org-get-agenda-file-buffer orgfile)
         (org-caldav-debug-print
          2 (format "Checking %s for new entries & unsaved changes" orgfile))
+        (unless org-caldav-skip-create-uid
+          (org-caldav-create-uid orgfile t))
         (when (and org-caldav-save-buffers
                    (buffer-modified-p))
           (org-caldav-debug-print 2 (format "Saving %s" orgfile))

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1771,8 +1771,6 @@ Returns buffer containing the ICS file."
       (with-current-buffer (org-get-agenda-file-buffer orgfile)
         (org-caldav-debug-print
          2 (format "Checking %s for new entries & unsaved changes" orgfile))
-        (unless org-caldav-skip-create-uid
-          (org-caldav-create-uid orgfile t))
         (when (and org-caldav-save-buffers
                    (buffer-modified-p))
           (org-caldav-debug-print 2 (format "Saving %s" orgfile))

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -193,6 +193,10 @@ might loose information in your Org items (take a look at
           (const timestamp-only :tag "Sync only the timestamp")
           (const all :tag "Sync everything")))
 
+(defcustom org-caldav-skip-create-uid nil
+  "Whether to generate UID for headers."
+  :type 'boolean)
+
 (defcustom org-caldav-days-in-past nil
   "Number of days before today to skip in the exported calendar.
 This makes it very easy to keep the remote calendar clean.
@@ -1767,7 +1771,8 @@ Returns buffer containing the ICS file."
       (with-current-buffer (org-get-agenda-file-buffer orgfile)
         (org-caldav-debug-print
          2 (format "Checking %s for new entries & unsaved changes" orgfile))
-        (org-caldav-create-uid orgfile t)
+        (unless org-caldav-skip-create-uid
+          (org-caldav-create-uid orgfile t))
         (when (and org-caldav-save-buffers
                    (buffer-modified-p))
           (org-caldav-debug-print 2 (format "Saving %s" orgfile))


### PR DESCRIPTION
# Why
- when using `org-roam` there is already a mechanism for creating `:ID:` property.
- when filtering by tag with `org-caldav-select-tags` UIDs are generated for entries that should be filtered
- using `org-caldav-skip-conditions` is not sufficient as it creates `:ID:` properties for parent entries:
```org-mode
* Calendar events
  # unecessary properties
  ** Event
  :PROPERTY:
  :ID: ...
  :END:
  <2025-01-04 Sat 13:00-14:00>
  Example event
```  
