### PR TITLE
Escape asterisk lines in imported event descriptions

### DIFF
--- a/org-caldav-tests.el
+++ b/org-caldav-tests.el
@@ -551,6 +551,25 @@ Org task 2
 				    "\\s-*The description\n")
 			    (write-entry "1" nil))))))
 
+(ert-deftest org-caldav-03b-insert-org-entry-asterisk-description ()
+  "Description lines starting with asterisks must not become headings."
+  (let ((entry '((start-d . "01 01 2015")
+                 (start-t . "19:00")
+                 (end-d . "01 01 2015")
+                 (end-t . "20:00")
+                 (summary . "The summary")
+                 (description . "Agenda:\n* First item\n** Second item\nDone.")
+                 (location . "location")))
+        (org-caldav-select-tags ""))
+    (with-temp-buffer
+      (org-mode)
+      (org-caldav-insert-org-event-or-todo
+       (append entry '((uid . "1") (level . nil))))
+      ;; Only the event heading itself may be a heading.
+      (should (= 1 (length (org-map-entries t nil nil))))
+      (should (string-match "First item" (buffer-string)))
+      (should (string-match "Second item" (buffer-string))))))
+
 (ert-deftest org-caldav-04-multiple-calendars ()
   (org-caldav-test-setup-temp-files)
   (with-current-buffer (find-file-noselect org-caldav-test-orgfile)

--- a/org-caldav-tests.el
+++ b/org-caldav-tests.el
@@ -561,14 +561,22 @@ Org task 2
                  (description . "Agenda:\n* First item\n** Second item\nDone.")
                  (location . "location")))
         (org-caldav-select-tags ""))
+    (dolist (org-caldav-description-heading-escape '(zero-width-space space))
+      (with-temp-buffer
+        (org-mode)
+        (org-caldav-insert-org-event-or-todo
+         (append entry '((uid . "1") (level . nil))))
+        ;; Only the event heading itself may be a heading.
+        (should (= 1 (length (org-map-entries t nil nil))))
+        (should (string-match "First item" (buffer-string)))
+        (should (string-match "Second item" (buffer-string)))))
+    ;; Stripping the zero width spaces from an exported ICS buffer
+    ;; restores the original asterisk lines.
     (with-temp-buffer
-      (org-mode)
-      (org-caldav-insert-org-event-or-todo
-       (append entry '((uid . "1") (level . nil))))
-      ;; Only the event heading itself may be a heading.
-      (should (= 1 (length (org-map-entries t nil nil))))
-      (should (string-match "First item" (buffer-string)))
-      (should (string-match "Second item" (buffer-string))))))
+      (insert "DESCRIPTION:Agenda:\\n\u200B* First item\\n\u200B** Second item\n")
+      (org-caldav-strip-zero-width-spaces)
+      (should (equal (buffer-string)
+                     "DESCRIPTION:Agenda:\\n* First item\\n** Second item\n")))))
 
 (ert-deftest org-caldav-04-multiple-calendars ()
   (org-caldav-test-setup-temp-files)

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -383,20 +383,9 @@ the unit tests to fail otherwise."
   :type 'boolean)
 
 (defcustom org-caldav-description-heading-escape 'zero-width-space
-  "How to escape asterisk lines in imported event descriptions.
-Description lines starting with asterisks would otherwise be parsed
-as Org headings and corrupt the entry structure of the inbox (see
-issue #323).
-
-`zero-width-space' prefixes such lines with a zero width space
-\(U+200B), as recommended by the Org manual.  The escape character is
-stripped again when the entry is exported back to the calendar
-server, so the description round-trips unchanged.
-
-`space' uses a visible space instead.  Org then treats such lines as
-plain list items, which reads nicely in the inbox, but they are
-exported back as list bullets (e.g. \='‣\='), so the original asterisks
-are not restored on the server."
+  "How to escape leading asterisks in imported descriptions.
+`zero-width-space' uses U+200B, removed on export.
+`space' uses visible indentation but may change bullets on export."
   :type '(choice (const :tag "Zero width space (U+200B)" zero-width-space)
                  (const :tag "Space" space)))
 

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -382,6 +382,24 @@ have trouble finding IDs in unsaved buffers, causing syncs and
 the unit tests to fail otherwise."
   :type 'boolean)
 
+(defcustom org-caldav-description-heading-escape 'zero-width-space
+  "How to escape asterisk lines in imported event descriptions.
+Description lines starting with asterisks would otherwise be parsed
+as Org headings and corrupt the entry structure of the inbox (see
+issue #323).
+
+`zero-width-space' prefixes such lines with a zero width space
+\(U+200B), as recommended by the Org manual.  The escape character is
+stripped again when the entry is exported back to the calendar
+server, so the description round-trips unchanged.
+
+`space' uses a visible space instead.  Org then treats such lines as
+plain list items, which reads nicely in the inbox, but they are
+exported back as list bullets (e.g. \='‣\='), so the original asterisks
+are not restored on the server."
+  :type '(choice (const :tag "Zero width space (U+200B)" zero-width-space)
+                 (const :tag "Space" space)))
+
 (defcustom org-caldav-description-blank-line-before t
   "Whether DESCRIPTION inserted into org should be preceded by blank line."
   :type 'boolean)
@@ -1793,7 +1811,9 @@ Returns buffer containing the ICS file."
                        '(org-caldav-scheduled-from-deadline)))))
         ;; Export events to one single ICS file.
         (apply 'org-icalendar--combine-files orgfiles)))
-    (find-file-noselect (symbol-value icalendar-file))))
+    (with-current-buffer (find-file-noselect (symbol-value icalendar-file))
+      (org-caldav-strip-zero-width-spaces)
+      (current-buffer))))
 
 (defun org-caldav-get-uid ()
   "Get UID for event in current buffer."
@@ -1886,15 +1906,31 @@ Do nothing if LEVEL is larger than `org-caldav-debug-level'."
       ;; Escape any remaining lines starting with asterisks (whatever
       ;; their level), so the description cannot break the heading
       ;; structure of the inbox (see issue #323).  This must happen
-      ;; after `org-indent-region', which would re-indent such lines
-      ;; back to column 0.
-      (let ((end (point-marker)))
+      ;; after `org-indent-region', which would re-indent
+      ;; space-escaped lines back to column 0.
+      (let ((end (point-marker))
+            (esc (org-caldav--description-escape-string)))
         (save-excursion
           (goto-char beg)
           (while (re-search-forward "^\\*" end t)
-            (replace-match " *" t t)))))
+            (replace-match (concat esc "*") t t)))))
     (when org-caldav-description-blank-line-after (newline))
     (newline)))
+
+(defun org-caldav--description-escape-string ()
+  "Return the escape string according to `org-caldav-description-heading-escape'."
+  (if (eq org-caldav-description-heading-escape 'space) " " "\u200B"))
+
+(defun org-caldav-strip-zero-width-spaces ()
+  "Remove zero width spaces (U+200B) from the current buffer.
+Inverse of the escaping done by `org-caldav--insert-description':
+zero-width-space escaped asterisk lines survive the icalendar export
+literally, so stripping the escape character from the exported ICS
+restores the original description on the calendar server."
+  (save-excursion
+    (goto-char (point-min))
+    (while (search-forward "\u200B" nil t)
+      (replace-match "" t t))))
 
 (defun org-caldav-insert-org-event-or-todo (eventdata-alist)
   "Insert org block from given event data at current position.

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1882,7 +1882,17 @@ Do nothing if LEVEL is larger than `org-caldav-debug-level'."
     (when org-caldav-description-blank-line-before (newline))
     (let ((beg (point)))
       (insert description)
-      (org-indent-region beg (point)))
+      (org-indent-region beg (point))
+      ;; Escape any remaining lines starting with asterisks (whatever
+      ;; their level), so the description cannot break the heading
+      ;; structure of the inbox (see issue #323).  This must happen
+      ;; after `org-indent-region', which would re-indent such lines
+      ;; back to column 0.
+      (let ((end (point-marker)))
+        (save-excursion
+          (goto-char beg)
+          (while (re-search-forward "^\\*" end t)
+            (replace-match " *" t t)))))
     (when org-caldav-description-blank-line-after (newline))
     (newline)))
 


### PR DESCRIPTION
Fixes #323.

When an imported event's description contains lines starting with asterisks (common in meeting invites that use `*` bullets), they were inserted verbatim into the inbox and org parsed them as top-level headings. Consequences:

- The entry's `ID`/`LOCATION` properties end up attached to the last bogus heading instead of the event heading.
- On subsequent syncs each bogus heading is treated as an event that was deleted in org, so org-caldav prompts to delete entries from the external calendar.

Example description that triggers it:

```
Agenda:
* First item
** Second item
```

The fix escapes any line starting with an asterisk (any level, per the suggestion in #323) by prefixing a space. This has to happen after the existing `org-indent-region` call: escaping first turns those lines into list items, which `org-indent-region` re-indents back to column 0, recreating the headings.

Includes a unit test (`org-caldav-03b-insert-org-entry-asterisk-description`) asserting the inserted entry contains exactly one heading.