### PR TITLE
Name the Org entry in local deletion confirmations

### DIFF
--- a/org-caldav-tests.el
+++ b/org-caldav-tests.el
@@ -482,6 +482,46 @@ Org task 2
 
   )
 
+(ert-deftest org-caldav-test-local-deletion-prompt ()
+  "Identify the local entry and honor both confirmation answers."
+  (dolist (answer '(nil t))
+    (with-temp-buffer
+      (org-mode)
+      (insert "* Keep this entry\n* TODO [#A] Test \"event\" :calendar:\n")
+      (add-text-properties (point-min) (point-max) '(face bold))
+      (goto-char (point-min))
+      (let ((before (buffer-string))
+            (org-caldav-event-list (list (list "test-uid" 'deleted-in-cal)))
+            (org-caldav-delete-org-entries 'ask)
+            (org-caldav-save-buffers nil)
+            (org-caldav-debug-level 0)
+            (org-caldav-calendar-id "test")
+            org-caldav-sync-result seen-prompt)
+        (cl-letf (((symbol-function 'org-id-goto)
+                   (lambda (uid)
+                     (should (equal uid "test-uid"))
+                     (goto-char (point-min))
+                     (re-search-forward "^\\* TODO")
+                     (beginning-of-line)))
+                  ((symbol-function 'y-or-n-p)
+                   (lambda (prompt)
+                     (setq seen-prompt prompt)
+                     answer)))
+          (org-caldav-update-events-in-org))
+        (should (equal seen-prompt
+                       "Delete local Org entry \"Test \\\"event\\\"\"? "))
+        (if answer
+            (progn
+              (should (equal (buffer-string) "* Keep this entry\n"))
+              (should-not org-caldav-event-list)
+              (should (equal org-caldav-sync-result
+                             '(("test" "test-uid" deleted-in-cal
+                                removed-from-org)))))
+          (should (equal (buffer-string) before))
+          (should (equal org-caldav-event-list
+                         '(("test-uid" deleted-in-cal))))
+          (should-not org-caldav-sync-result))))))
+
 (ert-deftest org-caldav-02-change-heading-test ()
   (with-current-buffer (get-buffer-create "headingtest")
     (erase-buffer)

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1596,7 +1596,10 @@ which can only be synced to calendar. Ignoring." uid))
       (org-id-goto (car cur))
       (when (or (eq org-caldav-delete-org-entries 'always)
 		(and (eq org-caldav-delete-org-entries 'ask)
-		     (y-or-n-p "Delete this entry locally? ")))
+		     (y-or-n-p
+                      (format "Delete local Org entry %S? "
+                              (substring-no-properties
+                               (org-get-heading t t t t))))))
 	(delete-region (org-entry-beginning-position)
 		       (org-entry-end-position))
         (when org-caldav-save-buffers (save-buffer))


### PR DESCRIPTION
When an event has been deleted from the remote calendar, org-caldav jumps to the corresponding Org entry but asks only `Delete this entry locally?`. The target can be hard to identify from the current window or folded outline.

Include the local heading in the confirmation instead:

```
Delete local Org entry "Test appointment"? (y or n)
```

Strip TODO keywords, priority, tags, and text properties from the heading used in the prompt. Keep the existing entry navigation, confirmation policy, and deletion behavior unchanged.

The regression test exercises `org-caldav-update-events-in-org` with temporary Org data. It checks the prompt for a decorated heading containing quotes, verifies that declining preserves the entry and sync state, and verifies that accepting removes only the targeted entry. No network or file saves are involved.

### Verification

The new test fails on unmodified upstream with the generic prompt, then passes with this change. Four server-free tests pass on GNU Emacs 31.1:

```sh
emacs -Q --batch -L . \
  --eval '(setq org-caldav-url "https://example.invalid/")' \
  -l org-caldav-tests.el \
  --eval '(ert-run-tests-batch-and-exit (quote (member org-caldav-test-local-deletion-prompt org-caldav-02-change-heading-test org-caldav-03-insert-org-entry org-caldav-test-multiline-location)))'
```

The server-dependent integration tests were not run.
